### PR TITLE
Remove CouchDB vhost configuration.

### DIFF
--- a/test/couch/config.ini
+++ b/test/couch/config.ini
@@ -23,6 +23,3 @@ timeout = 36000
 allow_persistent_cookies = true
 public_fields = appdotnet, avatar, avatarMedium, avatarLarge, date, email, fields, freenode, fullname, github, homepage, name, roles, twitter, type, _id, _rev
 users_db_public = true
-
-[vhosts]
-127.0.0.1:15984 = /registry/_design/app/_rewrite

--- a/test/helpers/couch-registry.js
+++ b/test/helpers/couch-registry.js
@@ -19,8 +19,7 @@ var couchPassword = 'admin';
 var authenticatedAdminUrl = util.format('http://%s:%s@localhost:%d',
                                         couchUser, couchPassword, port);
 
-// 127.0.0.1 is mapped to /registry/_design/app/_rewrite
-var registryUrl = 'http://127.0.0.1:' + port;
+var registryUrl = couchAdminUrl + '/registry/_design/app/_rewrite';
 
 exports.userCredentials = couchUser + ':' + couchPassword;
 


### PR DESCRIPTION
Use the full `_design/app/_rewrite` URL for the registry, as discussed in #1.

Before this change,
- `http://localhost:15984/` was the CouchDB REST API,
-  `http://127.0.0.1:15984/` was the npm registry REST API.

This commit removes the difference between localhost and 127.0.0.1.

The npm registry REST API must be accessed via
- `http://{host:port}/_design/app/_rewrite`

/to: @rmg 
