### PR TITLE
Add jshint pretest, prevent stdout pollution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@
 *.pid
 *.swp
 *.swo
+*.tgz
+*.gz
 node_modules
 sandbox

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "test"
   },
   "scripts": {
+    "pretest": "jshint .",
     "test": "mocha"
   },
   "repository": {
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "couchapp": "^0.10.0",
-    "npmjs.org": "^1.2.0"
+    "npmjs.org": "^1.2.0",
+    "jshint": "^2.4.4"
   }
 }

--- a/test/helpers/couch-registry.js
+++ b/test/helpers/couch-registry.js
@@ -105,18 +105,18 @@ function uploadRegistryApp() {
   }
 
   function upload() {
-    var npmjs_org = require('npmjs.org/registry/app.js');
+    var npmjsApp = require('npmjs.org/registry/app.js');
 
     // the npmjs.org workflow pushes this app as _design/scratch so that the
     // indexes can be generated out of band and then COPY is used to update
     // _design/app with _design/scratch.
-    npmjs_org._id = '_design/app';
+    npmjsApp._id = '_design/app';
 
     return new Promise(function pushCouchApp(resolve, reject) {
-      couchapp.createApp(npmjs_org, authedDatabaseUrl, function(app) {
+      couchapp.createApp(npmjsApp, authedDatabaseUrl, function(app) {
         app.push(resolve);
       });
-    })
+    });
   }
 }
 

--- a/test/helpers/couch-registry.js
+++ b/test/helpers/couch-registry.js
@@ -112,10 +112,18 @@ function uploadRegistryApp() {
     // _design/app with _design/scratch.
     npmjsApp._id = '_design/app';
 
+    // redirect console.log messages printed by couchapp to debug log
+    var _log = console.log;
+    console.log = function() {
+      debug.apply(debug, arguments);
+    };
+
     return new Promise(function pushCouchApp(resolve, reject) {
       couchapp.createApp(npmjsApp, authedDatabaseUrl, function(app) {
         app.push(resolve);
       });
+    }).finally(function() {
+      console.log = _log;
     });
   }
 }


### PR DESCRIPTION
Add jshint as "pretest" script, fix the issues discovered.

Prevent `couchapp messages from polluting stdout by temporarily redirecting console.log to the debug log.

/to @rmg please review.

Once this patch has landed, I think the module is ready for the first release.
