### PR TITLE
Add more end-to-end tests

### DIFF
--- a/lib/end-to-end/install.e2e.js
+++ b/lib/end-to-end/install.e2e.js
@@ -13,7 +13,7 @@ describe('install', function() {
   it('downloads correct package contents', function() {
     return given.publishedPackage()
       .then(function(pkg) {
-        return npm('install', targetDir, pkg.nameAtVersion).return(pkg);
+        return npm.install(targetDir, pkg.nameAtVersion).return(pkg);
       }).then(function(pkg) {
         var installedIndex = path.resolve(
           targetDir, 'node_modules', pkg.name, 'index.js');
@@ -34,7 +34,7 @@ describe('install', function() {
         return given.publishedPackage(pkg);
       })
       .then(function(pkg) {
-        return npm('install', targetDir, pkg.name + '@~1.0.0').return(pkg);
+        return npm.install(targetDir, pkg.name + '@~1.0.0').return(pkg);
       })
       .then(function(pkg) {
         var meta = require(targetDir + '/node_modules/' +
@@ -44,7 +44,7 @@ describe('install', function() {
   });
 
   it('returns error when package name does not exist', function() {
-    return npm('install', targetDir, 'unknown-package')
+    return npm.install(targetDir, 'unknown-package')
       .then(installShouldHaveFailed, expectError(/^404 Not Found/));
   });
 
@@ -53,7 +53,7 @@ describe('install', function() {
     return given.publishedPackage({ version: '1.0.0' })
       .then(function(pkg) {
         req = pkg.name + '@2.0.0';
-        return npm('install', targetDir, req);
+        return npm.install(targetDir, req);
       })
       .then(installShouldHaveFailed, expectError(/^version not found/));
   });

--- a/lib/end-to-end/publish.e2e.js
+++ b/lib/end-to-end/publish.e2e.js
@@ -10,7 +10,7 @@ describe('publish', function() {
   it('returns success', function() {
     var pkg = given.packageSync();
     debug('going to publish %j', pkg.path);
-    return npm('publish', [pkg.path])
+    return npm.publish(pkg.path)
       .then(function() {
         debug('result: %j', Array.prototype.slice.call(arguments));
       });
@@ -19,12 +19,12 @@ describe('publish', function() {
   it('returns error when package version already exists', function() {
     return given.publishedPackage()
       .then(function(pkg) {
-        return npm('publish', [pkg.path]).return(pkg);
+        return npm.publish(pkg.path).return(pkg);
       })
       // Strangely enough, it takes three invocations of `npm publish`
       // to get the error
       .then(function(pkg) {
-        return npm('publish', [pkg.path]);
+        return npm.publish(pkg.path);
       })
       .then(
         publishShouldHaveFailed,

--- a/lib/end-to-end/publish.e2e.js
+++ b/lib/end-to-end/publish.e2e.js
@@ -1,6 +1,7 @@
 var fs = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
+var config = require('../config');
 var npm = require('../npm-exec');
 var given = require('../given');
 var expect = require('chai').expect;
@@ -29,6 +30,24 @@ describe('publish', function() {
       .then(
         publishShouldHaveFailed,
         expectError(/cannot modify pre-existing version/));
+  });
+
+  it('sets tag to "latest"', function() {
+    var workDir = config.resolveSandboxPath('work');
+    fs.mkdirsSync(workDir);
+
+    return given.publishedPackage()
+      .then(function(pkg) {
+        return npm.install(workDir, pkg.name + '@latest').return(pkg);
+      })
+      .then(function(pkg) {
+        var jsonFile = path.join(
+          workDir, 'node_modules',
+          pkg.name, 'package.json');
+
+        var from = require(jsonFile)._from;
+        expect(from).to.equal(pkg.name + '@latest');
+      });
   });
 
   function publishShouldHaveFailed() {

--- a/lib/end-to-end/tag.e2e.js
+++ b/lib/end-to-end/tag.e2e.js
@@ -1,0 +1,44 @@
+var fs = require('fs-extra');
+var path = require('path');
+var debug = require('debug')('registry-validator:end-to-end:install');
+var expect = require('chai').expect;
+
+var npm = require('../npm-exec');
+var config = require('../config');
+var given = require('../given');
+
+describe('tag', function() {
+  var WORK_DIR = config.resolveSandboxPath('work');
+
+  var pkg;
+  before(function() {
+    return given.publishedPackage()
+      .then(function(data) {
+        pkg = data;
+      });
+  });
+
+  beforeEach(resetWorkDir);
+
+  it('sets custom tag', function() {
+    return npm.tag(pkg.nameAtVersion, 'stable')
+      .then(function() {
+        return npm.install(WORK_DIR, pkg.name + '@stable');
+      })
+      .then(expectPackageFrom(pkg.name + '@stable'));
+  });
+
+  function expectPackageFrom(spec) {
+    return function() {
+      var jsonFile = path.join(
+        WORK_DIR, 'node_modules',
+        pkg.name, 'package.json');
+      var from = require(jsonFile)._from;
+      expect(from).to.equal(spec);
+    };
+  }
+
+  function resetWorkDir() {
+    fs.mkdirsSync(WORK_DIR);
+  }
+});

--- a/lib/end-to-end/update.e2e.js
+++ b/lib/end-to-end/update.e2e.js
@@ -1,0 +1,37 @@
+var fs = require('fs-extra');
+var path = require('path');
+var expect = require('chai').expect;
+
+var npm = require('../npm-exec');
+var config = require('../config');
+var given = require('../given');
+
+describe('update', function() {
+  var targetDir = config.resolveSandboxPath('work');
+  var pkg;
+
+  it('downloads correct version', function() {
+    fs.mkdirsSync(targetDir);
+    // publish 1.0.0
+    return given.publishedPackage({ version: '1.0.0' })
+      .then(function(p) {
+        pkg = p;
+        // install 1.0.0
+        return npm.install(targetDir, pkg.name);
+      })
+      .then(function() {
+        // publish 1.0.1
+        return given.publishedPackage({ name: pkg.name, version: '1.0.1' });
+      })
+      .then(function() {
+        // update
+        return npm.update(targetDir);
+      })
+      .then(function() {
+        // assert version 1.1.0
+        var meta = require(targetDir + '/node_modules/' +
+          pkg.name + '/package.json');
+        expect(meta.version).to.equal('1.0.1');
+      });
+  });
+});

--- a/lib/given.js
+++ b/lib/given.js
@@ -39,5 +39,5 @@ given.packageSync = function(packageJson) {
 
 given.publishedPackage = function(packageJson) {
   var pkg = given.packageSync(packageJson);
-  return npm('publish', [pkg.path]).then(function() { return pkg; });
+  return npm.publish(pkg.path).then(function() { return pkg; });
 };

--- a/lib/npm-exec.js
+++ b/lib/npm-exec.js
@@ -8,7 +8,24 @@ var config = require('./config');
 
 var loadConfig = Promise.promisify(npm.load, npm);
 
-exports = module.exports = executeNpmCommand;
+exports.install = function(workingDir, packageSpecifier) {
+  return executeNpmCommand('install', workingDir, packageSpecifier);
+};
+
+exports.publish = function(dirOrTarball) {
+  return executeNpmCommand('publish', [dirOrTarball]);
+};
+
+exports.tag = function(nameAtVersion, tag) {
+  return executeNpmCommand('tag', [nameAtVersion, tag]);
+};
+
+exports.update = function(workingDir, modulesToUpdate) {
+  return executeNpmCommand(
+    { prefix: workingDir },
+    'update',
+    modulesToUpdate || []);
+};
 
 /**
  * @param options npm config

--- a/lib/npm-exec.js
+++ b/lib/npm-exec.js
@@ -2,11 +2,8 @@ var path = require('path');
 var extend = require('util')._extend;
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs-extra'));
-var npm = require('npm');
 var debug = require('debug')('registry-validator:npm');
 var config = require('./config');
-
-var loadConfig = Promise.promisify(npm.load, npm);
 
 exports.install = function(workingDir, packageSpecifier) {
   return executeNpmCommand('install', workingDir, packageSpecifier);
@@ -53,13 +50,13 @@ function executeNpmCommand(options, command, cmdArgs) {
       debug('loading %j', npmConf);
       return loadConfig(npmConf);
     })
-    .then(function() {
+    .then(function(npm) {
       debug('executing %s %j', command, args);
-      return callCommand(args, command);
+      return callCommand(npm, command, args);
     });
 }
 
-function callCommand(args, command) {
+function callCommand(npm, command, args) {
   var _log = console.log;
   console.log = function() {
     debug.apply(debug, arguments);
@@ -87,6 +84,35 @@ function callCommand(args, command) {
   }).finally(function() {
     console.log = _log;
   });
+}
+
+function loadConfig(options) {
+  // npm remembers whether the config was loaded
+  // and skips config loading when called second time
+  // we have to remove npm from the require cache to force
+  // config reload
+  purgeNpmFromRequireCache();
+  var npm = require('npm');
+  var load = Promise.promisify(npm.load, npm);
+  return load(options).return(npm);
+}
+
+function purgeNpmFromRequireCache() {
+  var npmPath = require.resolve('npm');
+  if (!/\/lib\/npm\.js/.test(npmPath))
+    throw new Error('Unexpected npm.main "' + npmPath + '"');
+
+  var prefix = path.dirname(path.dirname(npmPath)) + path.sep;
+  var modulesPrefix = path.join(prefix, 'node_modules') + path.sep;
+
+  for (var key in  require.cache) {
+    // Check if this is a file inside npm tree
+    if (key.substr(0, prefix.length) != prefix) continue;
+    // Check if this is an own file of npm, not a sub-module in node_modules
+    if (key.substr(0, modulesPrefix.length) == modulesPrefix) continue;
+    // Purge such file
+    delete require.cache[key];
+  }
 }
 
 function getConfig(options) {


### PR DESCRIPTION
The first commit cleans up the code, making it easier to refactor npm-exec internals.

The second commit fixes a bug where `npm.load` did not load the configuration.

The third commit adds tests for version tagging and `npm update`.

/to @rmg please review.
