### PR TITLE
Relax error message checks

### DIFF
--- a/lib/end-to-end/install.e2e.js
+++ b/lib/end-to-end/install.e2e.js
@@ -45,7 +45,7 @@ describe('install', function() {
 
   it('returns error when package name does not exist', function() {
     return npm.install(targetDir, 'unknown-package')
-      .then(installShouldHaveFailed, expectError(/^404 Not Found/));
+      .then(installShouldHaveFailed, expectErrorWithStatusCode(404));
   });
 
   it('returns error when package version does not exist', function() {
@@ -55,7 +55,7 @@ describe('install', function() {
         req = pkg.name + '@2.0.0';
         return npm.install(targetDir, req);
       })
-      .then(installShouldHaveFailed, expectError(/^version not found/));
+      .then(installShouldHaveFailed, expectErrorWithStatusCode(404));
   });
 
   beforeEach(function() {
@@ -68,9 +68,9 @@ describe('install', function() {
     throw new Error('npm install should have failed');
   }
 
-  function expectError(matcher) {
+  function expectErrorWithStatusCode(code) {
     return function(err) {
-      expect(err.message).to.match(matcher);
+      expect(err.statusCode).to.equal(code);
     };
   }
 });

--- a/lib/npm-exec.js
+++ b/lib/npm-exec.js
@@ -94,7 +94,29 @@ function loadConfig(options) {
   purgeNpmFromRequireCache();
   var npm = require('npm');
   var load = Promise.promisify(npm.load, npm);
-  return load(options).return(npm);
+  return load(options)
+    .then(function() {
+      // Monkey patch npm-registry-client to include
+      // HTTP response details in error objects
+      npm.registry.request = createErrorPatchingRequest(npm.registry.request);
+    })
+    .return(npm);
+}
+
+function createErrorPatchingRequest(request) {
+  return function() {
+    var args = Array.prototype.slice.call(arguments);
+    var cb = args.pop();
+
+    args.push(function patchCallback(err, remoteData, raw, response) {
+      if (err && response) {
+        err.statusCode = response.statusCode;
+      }
+      cb.apply(this, arguments);
+    });
+
+    request.apply(this, args);
+  };
 }
 
 function purgeNpmFromRequireCache() {


### PR DESCRIPTION
Monkey-patch npm-registry-client `request` method to include http status
code in the error object.

Modify `install` end-to-end tests to check 404 status code and ignore
error message, because the message may differ between registry
implementations.

Related discussion: rlidwka/sinopia#57

/to @rmg please review.
