### PR TITLE
lib/npm-exec: fix windows issues

### DIFF
--- a/lib/npm-exec.js
+++ b/lib/npm-exec.js
@@ -120,12 +120,9 @@ function createErrorPatchingRequest(request) {
 }
 
 function purgeNpmFromRequireCache() {
-  var npmPath = require.resolve('npm');
-  if (!/\/lib\/npm\.js/.test(npmPath))
-    throw new Error('Unexpected npm.main "' + npmPath + '"');
-
-  var prefix = path.dirname(path.dirname(npmPath)) + path.sep;
-  var modulesPrefix = path.join(prefix, 'node_modules') + path.sep;
+  var npmRoot = path.dirname(require.resolve('npm/package.json'));
+  var prefix = npmRoot + path.sep;
+  var modulesPrefix = path.join(npmRoot, 'node_modules') + path.sep;
 
   for (var key in  require.cache) {
     // Check if this is a file inside npm tree
@@ -139,8 +136,9 @@ function purgeNpmFromRequireCache() {
 
 function getConfig(options) {
   var result = extend({
-    userconfig: './user.npmrc',     // missing by default
-    globalconfig: './global.npmrc', // missing by default
+    // the following two paths intentionally point to non-existing files
+    userconfig: path.resolve(config.sandbox, 'user.npmrc'),
+    globalconfig: path.resolve(config.sandbox, 'global.npmrc'),
     cache: config.npmCache,
     registry: config.registryUrl
   }, options);


### PR DESCRIPTION
Use `path.sep` instead of hard-coded `/` separator.

/to: @rmg please review.
